### PR TITLE
Update to use POSIX paths for compatibility with MkDocs starting from version 1.4.0 under Windows

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018 Zach Hannum 
+Copyright (c) 2023 Arterm Sedov 
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ plugins:
 
 > **Note:** If you have no `plugins` entry in your config file yet, you'll likely also want to add the `search` plugin. MkDocs enables it by default if there is no `plugins` entry set, but now you have to enable it explicitly.
 
-More information about plugins in the [MkDocs documentation][mkdocs-plugins].
+More information about plugins in the [MkDocs documentation](https://www.mkdocs.org/dev-guide/plugins/).
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Original version of Autolinks 0.6.0 was not compatible with MkDocs 1.4.0 under W
 
 Install the plugin using pip:
 
-`pip install mkdocs-autolinks-plugin`
+`pip install mkdocs-autolinks-posix-plugin`
 
 Activate the plugin in `mkdocs.yml`:
 ```yaml

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ An MkDocs plugin that simplifies relative linking between documents.
 
 The Autolinks plugins allows you to link to pages and images within your MkDocs site without provided the entire relative path to the file in your document structure.
 
-This plugin is a fork of https://github.com/zachhannum/mkdocs-autolinks-plugin
+This plugin is a fork of https://github.com/zachhannum/mkdocs-autolinks-plugin.
+
 This version adds support POSIX paths introduced in MkDocs 1.4.0.
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
-# MkDocs Autolinks Plugin
+# MkDocs Autolinks POSIX Plugin
 
 An MkDocs plugin that simplifies relative linking between documents.
 
 The Autolinks plugins allows you to link to pages and images within your MkDocs site without provided the entire relative path to the file in your document structure.
 
-## Setup 
+This plugin is a fork of https://github.com/zachhannum/mkdocs-autolinks-plugin
+This version adds support POSIX paths introduced in MkDocs 1.4.0.
+
+## Setup
 
 Install the plugin using pip:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ The Autolinks plugins allows you to link to pages and images within your MkDocs 
 
 This plugin is a fork of https://github.com/zachhannum/mkdocs-autolinks-plugin.
 
-This version adds support POSIX paths introduced in MkDocs 1.4.0.
+This version adds support POSIX paths introduced in MkDocs 1.4.0. 
+
+Original version of Autolinks 0.6.0 was not compatible with MkDocs 1.4.0 under Windows.
 
 ## Setup
 

--- a/mkdocs_autolinks_plugin/plugin.py
+++ b/mkdocs_autolinks_plugin/plugin.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import pathlib
 import re
 from urllib.parse import quote
 import logging
@@ -60,8 +61,8 @@ class AutoLinkReplacer:
             )
 
         abs_link_path = abs_link_paths[0]
-        rel_link_path = quote(os.path.relpath(abs_link_path, abs_linker_dir))
-
+        rel_link_path = quote(pathlib.PurePath(os.path.relpath(abs_link_path, abs_linker_dir)).as_posix())
+    
         # Construct the return link by replacing the filename with the relative path to the file
         return match.group(0).replace(match.group(3), rel_link_path)
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     long_description='An MkDocs plugin that automagically generates relative links between markdown pages',
     keywords='mkdocs',
     url='https://github.com/arterm-sedov/mkdocs-autolinks-plugin',
-    download_url='https://github.com/arterm-sedov/mkdocs-autolinks-plugin/archive/mkdocs-autolinks-posix-plugin-0.6.1.tar.gz',
+    download_url='https://github.com/arterm-sedov/mkdocs-autolinks-plugin/releases/download/v_061/mkdocs-autolinks-posix-plugin-0.6.1.tar.gz',
     author='Artem Sedov, forked from Zach Hannum',
     license='MIT',
     python_requires='>=2.7',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     keywords='mkdocs',
     url='https://github.com/arterm-sedov/mkdocs-autolinks-plugin',
     download_url='https://github.com/arterm-sedov/mkdocs-autolinks-plugin/releases/download/v_061/mkdocs-autolinks-posix-plugin-0.6.1.tar.gz',
-    author='Artem Sedov, forked from Zach Hannum',
+    author='Arterm Sedov, forked from Zach Hannum',
     license='MIT',
     python_requires='>=2.7',
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,14 @@
 from setuptools import setup, find_packages
 
 setup(
-    name='mkdocs-autolinks-plugin',
-    version='0.6.0',
-    description='An MkDocs plugin',
+    name='mkdocs-autolinks-posix-plugin',
+    version='0.6.1',
+    description='MkDocs Autolinks POSIX plugin',
     long_description='An MkDocs plugin that automagically generates relative links between markdown pages',
     keywords='mkdocs',
-    url='https://github.com/midnightprioriem/mkdocs-autolinks-plugin',
-    download_url='https://github.com/midnightprioriem/mkdocs-autolinks-plugin/archive/v_060.tar.gz',
-    author='Zach Hannum',
-    author_email='zacharyhannum@gmail.com',
+    url='https://github.com/arterm-sedov/mkdocs-autolinks-plugin',
+    download_url='https://github.com/arterm-sedov/mkdocs-autolinks-plugin/archive/mkdocs-autolinks-posix-plugin-0.6.1.tar.gz',
+    author='Artem Sedov, forked from Zach Hannum',
     license='MIT',
     python_requires='>=2.7',
     install_requires=[


### PR DESCRIPTION
The plugin version 0.6.0 does not work in Windows with MkDocs starting from version 1.4.0.

This commit implements POSIX relative paths for cross-platform compatibility with MkDocs v1.4.0 and above.

See:
[[https://www.mkdocs.org/about/release-notes/#upgrades-for-plugin-developers
https://github.com/mkdocs/mkdocs/pull/2930](https://www.mkdocs.org/about/release-notes/#replace-filesrc_path-to-not-deal-with-backslashes-2930)](https://www.mkdocs.org/about/release-notes/#replace-filesrc_path-to-not-deal-with-backslashes-2930)