### PR TITLE
Fix/deprecation warnings

### DIFF
--- a/mkdocs_autolinks_plugin/plugin.py
+++ b/mkdocs_autolinks_plugin/plugin.py
@@ -7,10 +7,8 @@ import logging
 from collections import defaultdict
 
 from mkdocs.plugins import BasePlugin
-from mkdocs.utils import warning_filter
 
 LOG = logging.getLogger("mkdocs.plugins." + __name__)
-LOG.addFilter(warning_filter)
 
 # For Regex, match groups are:
 #       0: Whole markdown link e.g. [Alt-text](url)


### PR DESCRIPTION
Hi, I've been using your plugin for a while (thanks!) and I use it as a dependency for my plugin [`mkdocs-newsletter`](https://github.com/lyz-code/mkdocs-newsletter). Recently my CI has started failing because part of your code is using the soon to be deprecated object `warning_filter`.

Sorry for the imports reorder, I use `isort` on my dev environment , and the regular expression change (due to `black`).

If you like the contribution can you please make a release? so that my CI stops failing.

Thanks!